### PR TITLE
Cross platform support, part 1

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,9 @@
 require "bundler/gem_tasks"
 
+if RbConfig::CONFIG['host_os'] =~ /mingw|cygwin/i
+  require "devkit"
+end
+
 require 'rake/extensiontask'
 Rake::ExtensionTask.new do |ext|
   ext.name    = 'memory_buffer'

--- a/ext/memory_buffer/extconf.rb
+++ b/ext/memory_buffer/extconf.rb
@@ -1,7 +1,7 @@
 require 'mkmf'
 
-have_func("memalign")
-have_func("posix_memalign")
-have_func("_aligned_malloc")
+unless have_func("memalign") || have_func("posix_memalign")
+  raise "Unsupported platform."
+end
 
 create_makefile("memory_buffer/memory_buffer");

--- a/ext/memory_buffer/extconf.rb
+++ b/ext/memory_buffer/extconf.rb
@@ -1,3 +1,7 @@
 require 'mkmf'
 
+have_func("memalign")
+have_func("posix_memalign")
+have_func("_aligned_malloc")
+
 create_makefile("memory_buffer/memory_buffer");

--- a/ext/memory_buffer/memory_buffer.c
+++ b/ext/memory_buffer/memory_buffer.c
@@ -22,13 +22,15 @@ mb_create_aligned(VALUE self, VALUE ralign, VALUE rlen) {
 	int     rc;
 	VALUE	asb;
 
-#ifdef __linux__
+#ifdef HAVE_MEMALIGN
 	abuf = memalign(align, len);
-#elif __APPLE__
+#elif HAVE_POSIX_MEMALIGN
 	rc = posix_memalign((void **)&abuf, align, len);
 	if (0 != rc) {
 		abuf = NULL;
 	}
+#else
+  abuf = _aligned_malloc(len, align);
 #endif
 
 	if (NULL == abuf) {

--- a/ext/memory_buffer/memory_buffer.c
+++ b/ext/memory_buffer/memory_buffer.c
@@ -19,12 +19,12 @@ mb_create_aligned(VALUE self, VALUE ralign, VALUE rlen) {
 	size_t	align	= (size_t)NUM2INT(ralign);
 	size_t	len		= (size_t)NUM2INT(rlen);
 	char	*abuf;
-	int     rc;
 	VALUE	asb;
 
 #ifdef HAVE_MEMALIGN
 	abuf = memalign(align, len);
 #elif HAVE_POSIX_MEMALIGN
+	int rc;
 	rc = posix_memalign((void **)&abuf, align, len);
 	if (0 != rc) {
 		abuf = NULL;

--- a/ext/memory_buffer/memory_buffer.c
+++ b/ext/memory_buffer/memory_buffer.c
@@ -30,7 +30,7 @@ mb_create_aligned(VALUE self, VALUE ralign, VALUE rlen) {
 		abuf = NULL;
 	}
 #else
-  abuf = _aligned_malloc(len, align);
+	abuf = _aligned_malloc(len, align);
 #endif
 
 	if (NULL == abuf) {

--- a/ext/memory_buffer/memory_buffer.c
+++ b/ext/memory_buffer/memory_buffer.c
@@ -23,14 +23,12 @@ mb_create_aligned(VALUE self, VALUE ralign, VALUE rlen) {
 
 #ifdef HAVE_MEMALIGN
 	abuf = memalign(align, len);
-#elif HAVE_POSIX_MEMALIGN
+#else
 	int rc;
 	rc = posix_memalign((void **)&abuf, align, len);
 	if (0 != rc) {
 		abuf = NULL;
 	}
-#else
-	abuf = _aligned_malloc(len, align);
 #endif
 
 	if (NULL == abuf) {


### PR DESCRIPTION
This PR dispenses with explicit platform checks, and instead checks for the functions memalign, posix_memalign and _aligned_malloc. The code will use the first of those that it finds, and in theory it should work on any platform that supports those functions.

In theory. ~~In reality, Solaris 10 seemed to have trouble with very large buffers, and I got a couple test failures.~~ It compiles and works on Windows, too, right up to the part where GC happens. Then it segfaults, I think because it needs _aligned_free (instead of just free) on deallocation, but I'm not sure how to make it use that function yet since we're messing directly with RSTRING.

Still, this gets us partway there. Oh, and I cleaned up one warning. :)
