### PR TITLE
Check for malloc.h header instead of Linux.

### DIFF
--- a/ext/memory_buffer/extconf.rb
+++ b/ext/memory_buffer/extconf.rb
@@ -4,4 +4,6 @@ unless have_func("memalign") || have_func("posix_memalign")
   raise "Unsupported platform."
 end
 
+have_header("malloc.h")
+
 create_makefile("memory_buffer/memory_buffer");

--- a/ext/memory_buffer/memory_buffer.c
+++ b/ext/memory_buffer/memory_buffer.c
@@ -6,7 +6,8 @@
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
-#ifdef __linux__
+
+#ifdef HAVE_MALLOC_H
 	#include <malloc.h>
 #endif
 


### PR DESCRIPTION
Just another minor cross-platform tweak that checks for malloc.h instead of explicitly checking for Linux.
